### PR TITLE
Times in the FA database are local. Closes #23

### DIFF
--- a/lib/fueling.rb
+++ b/lib/fueling.rb
@@ -2,6 +2,7 @@
 class Fueling < ActiveRecord::Base
   self.table_name = 'emsdba.FTK_MAIN'
   self.primary_key = 'row_id'
+  self.default_timezone = :local
 
   default_scope do
     order('ftk_date DESC').select 'qty_fuel AS amount',
@@ -10,5 +11,12 @@ class Fueling < ActiveRecord::Base
                                   'row_id AS fuel_focus_row_id',
                                   'X_datetime_insert AS time_at_insertion',
                                   'EQ_equip_no'
+  end
+
+  def inspect
+    attrs = { vehicle: self.EQ_equip_no,
+              amount: amount.to_f,
+              time_at: time_at }
+    "#<#{self.class} #{attrs}>"
   end
 end

--- a/lib/fueling.rb
+++ b/lib/fueling.rb
@@ -21,6 +21,6 @@ class Fueling < ActiveRecord::Base
   end
 
   def readonly?
-    true
+    ENV['RACK_ENV'] == 'test' ? super : true
   end
 end

--- a/lib/fueling.rb
+++ b/lib/fueling.rb
@@ -15,8 +15,12 @@ class Fueling < ActiveRecord::Base
 
   def inspect
     attrs = { vehicle: self.EQ_equip_no,
-              amount: amount.to_f,
-              time_at: time_at }
+              amount: qty_fuel.to_f,
+              time_at: ftk_date }
     "#<#{self.class} #{attrs}>"
+  end
+
+  def readonly?
+    true
   end
 end

--- a/spec/eam_app_spec.rb
+++ b/spec/eam_app_spec.rb
@@ -68,8 +68,9 @@ RSpec.describe EAMApp do
         get "/vehicle/3201/#{d1}/#{d2}"
         expect(fueling.count).to be(1)
 
-        # 'Z' and to_i to work-around a problem with sqlite and 'AS'
-        time_of_fueling = Time.parse(fueling.first.fetch('time_at') + 'Z').to_i
+        # 'Time.now.zone' and to_i to work-around a problem with sqlite and 'AS'
+        time_of_fueling = Time.parse(fueling.first.fetch('time_at') +
+                                     Time.now.zone).to_i
         expect(time_of_fueling).to eq(@twenty_days_ago.to_i)
       end
     end

--- a/spec/fueling_spec.rb
+++ b/spec/fueling_spec.rb
@@ -36,8 +36,13 @@ RSpec.describe Fueling do
     # I think this is a limitation of sqlite?
     # The result of "SELECT some_time AS other" returns a `String` in test
     # only.  There are other differences too, but they # don't break `#==`
-    expect(DateTime.parse(with_scope.time_at)).to eq(without_scope.ftk_date)
-    expect(DateTime.parse(with_scope.time_at_insertion))
-      .to eq(without_scope.X_datetime_insert)
+    ta_parsed = DateTime.parse(
+      "#{with_scope.time_at} #{Time.now.zone}"
+    )
+    tai_parsed = DateTime.parse(
+      "#{with_scope.time_at_insertion} #{Time.now.zone}"
+    )
+    expect(ta_parsed).to eq(without_scope.ftk_date)
+    expect(tai_parsed).to eq(without_scope.X_datetime_insert)
   end
 end


### PR DESCRIPTION
Have they always been? I don't think so, but this is the "fix", I guess.
This fix also required more wrangling in the specs to get around the
SQLite bug with `AS` clauses. Yuck.

Also added a meaningful `inspect` method for the console.