### PR TITLE
Fix sqlite schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config/database.yml
+db/test.db
+
 log/*
-db/test.sqlite3

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 ruby IO.read(File.expand_path('.ruby-version', __dir__)).strip
 
+gem 'json'
+gem 'psych'
 gem 'sinatra',              require: 'sinatra/base'
 gem 'sinatra-activerecord', require: 'sinatra/activerecord'
 
@@ -25,5 +27,6 @@ group :development do
   gem 'capistrano-bundler',   require: false
   gem 'capistrano-passenger', require: false
   gem 'capistrano-pending',   require: false
+  gem 'irb'
   gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
-    ostruct (0.1.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -99,8 +98,6 @@ GEM
     sshkit (1.18.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stringio (0.0.2)
-    strscan (1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tiny_tds (2.1.2)
@@ -121,7 +118,6 @@ DEPENDENCIES
   factory_bot
   irb
   json
-  ostruct
   pry
   psych
   rack-test
@@ -130,8 +126,6 @@ DEPENDENCIES
   sinatra
   sinatra-activerecord
   sqlite3
-  stringio
-  strscan
   tiny_tds (= 2.1.2)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,13 +40,16 @@ GEM
       activesupport (>= 3.0.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    irb (1.0.0)
     jaro_winkler (1.5.1)
+    json (2.2.0)
     method_source (0.9.2)
     minitest (5.11.3)
     mustermann (1.0.3)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
+    ostruct (0.1.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -54,6 +57,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    psych (3.1.0)
     rack (2.0.6)
     rack-protection (2.0.4)
       rack
@@ -95,6 +99,8 @@ GEM
     sshkit (1.18.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stringio (0.0.2)
+    strscan (1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tiny_tds (2.1.2)
@@ -113,13 +119,19 @@ DEPENDENCIES
   capistrano-pending
   database_cleaner
   factory_bot
+  irb
+  json
+  ostruct
   pry
+  psych
   rack-test
   rspec
   rubocop
   sinatra
   sinatra-activerecord
   sqlite3
+  stringio
+  strscan
   tiny_tds (= 2.1.2)
 
 RUBY VERSION

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -11,6 +11,6 @@ development:
 
 test:
   adapter: sqlite3
-  database: db/test.sqlite3
+  database: db/test.db
   pool: 5
   timeout: 5000

--- a/db/migrate/20161208163013_create_fuelings.rb
+++ b/db/migrate/20161208163013_create_fuelings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateFuelings < ActiveRecord::Migration
+class CreateFuelings < ActiveRecord::Migration[4.2]
   def change
     # note that this is a partial table compared to what's in the EAM DB,
     # but it contains all of the columns we actually use in this application.

--- a/db/migrate/20190528160745_rename_fuelings.rb
+++ b/db/migrate/20190528160745_rename_fuelings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RenameFuelings < ActiveRecord::Migration
+  def change
+    return if ActiveRecord.version >= Gem::Version.new('5.0')
+
+    rename_table 'emsdba.FTK_MAIN', 'FTK_MAIN'
+  end
+end

--- a/db/migrate/20190528161310_create_fuelings_again.rb
+++ b/db/migrate/20190528161310_create_fuelings_again.rb
@@ -1,17 +1,23 @@
 # frozen_string_literal: true
 
-class CreateFuelings < ActiveRecord::Migration
-  def change
-    return if ActiveRecord.version >= Gem::Version.new('5.0')
+class CreateFuelingsAgain < ActiveRecord::Migration
+  def up
+    return if table_exists? 'FTK_MAIN'
 
     # note that this is a partial table compared to what's in the EAM DB,
     # but it contains all of the columns we actually use in this application.
-    create_table 'emsdba.FTK_MAIN', primary_key: 'row_id' do |t|
+    create_table 'FTK_MAIN', primary_key: 'row_id' do |t|
       t.decimal  'qty_fuel'
       t.integer  'meter_1'
       t.datetime 'ftk_date'
       t.datetime 'X_datetime_insert'
       t.string   'EQ_equip_no'
     end
+  end
+
+  def down
+    return if ActiveRecord.version < Gem::Version.new('5.0')
+
+    drop_table 'FTK_MAIN'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161208163013) do
+ActiveRecord::Schema.define(version: 20190528161310) do
 
-  create_table "emsdba.FTK_MAIN", primary_key: "row_id", force: :cascade do |t|
+  create_table "FTK_MAIN", primary_key: "row_id", force: :cascade do |t|
     t.decimal  "qty_fuel"
     t.integer  "meter_1"
     t.datetime "ftk_date"

--- a/lib/fueling.rb
+++ b/lib/fueling.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Fueling < ActiveRecord::Base
-  self.table_name = 'emsdba.FTK_MAIN'
+  self.table_name_prefix = 'emsdba.' unless test?
+  self.table_name = 'FTK_MAIN'
   self.primary_key = 'row_id'
   self.default_timezone = :local
 
@@ -22,6 +23,10 @@ class Fueling < ActiveRecord::Base
   end
 
   def readonly?
-    ENV['RACK_ENV'] == 'test' ? super : true
+    test? ? super : true
+  end
+
+  def test?
+    ENV['RACK_ENV'] == 'test'
   end
 end

--- a/lib/fueling.rb
+++ b/lib/fueling.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Fueling < ActiveRecord::Base
-  self.table_name_prefix = 'emsdba.' unless test?
+  self.table_name_prefix = 'emsdba.' unless ENV['RACK_ENV'] == 'test'
   self.table_name = 'FTK_MAIN'
   self.primary_key = 'row_id'
   self.default_timezone = :local
@@ -23,10 +23,6 @@ class Fueling < ActiveRecord::Base
   end
 
   def readonly?
-    test? ? super : true
-  end
-
-  def test?
-    ENV['RACK_ENV'] == 'test'
+   ENV['RACK_ENV'] == 'test' ? super : true
   end
 end

--- a/lib/fueling.rb
+++ b/lib/fueling.rb
@@ -16,13 +16,10 @@ class Fueling < ActiveRecord::Base
   end
 
   def inspect
-    attrs = { vehicle: self.EQ_equip_no,
-              amount: qty_fuel.to_f,
-              time_at: ftk_date }
-    "#<#{self.class} #{attrs}>"
+    "#<#{self.class} #{attributes.slice('EQ_equip_no', 'amount', 'time_at')}>"
   end
 
   def readonly?
-   ENV['RACK_ENV'] == 'test' ? super : true
+    ENV['RACK_ENV'] == 'test' ? super : true
   end
 end


### PR DESCRIPTION
So, this one's going to take a bit of background.

Many databases have a concept of a "schema", a way to namespace all the tables in your connection/user rights. In FA, all the tables belong to a schema named `emsdba`, so that prefix is needed to tell MSSQL which table you're referring to.

When I created the semi-mock SQLite database for testing, i made the table with the name `"emsdba.FTK_MAIN"` so the same code could access it. Unfortunately in Rails 5, there was a "fix" that caused that name to be `"emsdba"."FTK_MAIN"` as if it were a schema (which it is in production) instead of a table name that happened to have a `.` in it.

In SQLite, that notation is for "attached" databases — where you mount one database inside another. Which isn't what we have.

Hence, the weird guard clauses in the migrations. You can't run the original migration at all in Rails 5, nor can you undo it in 5. I _guess_ this is the best way to do it? :man_shrugging: 