### PR TITLE
Fix pending role

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,6 +8,8 @@ set :deploy_to, "/srv/#{fetch :application}"
 
 set :log_level, :info
 
+set :capistrano_pending_role, :app
+
 append :linked_files, 'config/database.yml'
 append :linked_dirs, '.bundle', 'log', 'tmp/pids'
 


### PR DESCRIPTION
The default is :db (for some reason) and without any matching servers, `cap production deploy:pending` will just blithely do nothing.