### PR TITLE
Fallback to no specific version if file is missing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@
 
 source 'https://rubygems.org'
 ruby File.read(File.expand_path('.ruby-version', __dir__)).strip
-rails_version = File.read(File.expand_path('.rails-version', __dir__)).strip
+
+rails_version_file = File.expand_path('.rails-version', __dir__)
+rails_version = File.exist?(rails_version_file) ? File.read(rails_version_file).strip : nil
 
 gem 'exception_notification'
 gem 'json'


### PR DESCRIPTION
Dependapot only grabs certain files from the repo to do its analysis. `.ruby-version` is one of them, `.rails-version` is not. And so, dependabot currently can't make update PRs, because of an exception while parsing the Gemfile.

This _might_ cause Dependabot to author PRs which update activerecord-sqlserver-adaptor incorrectly, but that's better than not making any PRs.

I was looking into this because Dependabot didn't make #83, I had to do it.