### PR TITLE
Basic check for database connectivity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Metrics/BlockLength:
 Rails/CreateTableWithTimestamps:
   Enabled: false
 
+Rails/RakeEnvironment:
+  Enabled: false
+
 Rails/TimeZone:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,13 @@ if env == 'test'
   require 'sinatra/activerecord'
   require 'sinatra/activerecord/rake'
 end
+
+desc 'Check that we can connect to the database'
+task :check do
+  require 'sinatra/activerecord'
+  require 'application_record'
+  ApplicationRecord.establish_connection(env.to_sym)
+  ApplicationRecord.connection.execute('SELECT 1')
+
+  puts 'Database connection successful'
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,3 +15,5 @@ append :linked_files, 'config/database.yml'
 append :linked_dirs, '.bundle', 'log', 'tmp/pids'
 
 set :passenger_restart_with_sudo, true
+
+before 'deploy:publishing', 'db:check'

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc 'Check that we can connect to the database'
+  task :check do
+    on roles(:app) do
+      within release_path do
+        with rack_env: fetch(:stage) do
+          execute :rake, 'check'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Check the database before finishing deploy. On Rails apps, this isn't needed because Capistrano runs db:migrate. This at least will fail deploy if we can't `Bundler.require` and run a database query.

Closes #241