### PR TITLE
Add credentails tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+config/fleetfocus-api.yml.enc diff=credentials

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-pending', require: false
   gem 'ed25519', '>= 1.2', '< 2.0', require: false
+  gem 'railties', require: false
   gem 'rubocop', require: false
   gem 'rubocop-factory_bot', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,7 @@ DEPENDENCIES
   puma
   rack-test
   rails (~> 8.0.2)
+  railties
   rake
   rspec
   rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -19,3 +19,33 @@ task :check do
 
   puts 'Database connection successful'
 end
+
+namespace :credentials do
+  desc 'Outputs the credentials stored in `ARGV[1]` (used by diff helper)'
+  task :diff do
+    credentials = ActiveSupport::EncryptedConfiguration.new(
+      config_path: File.expand_path(ARGV[1], __dir__),
+      key_path: CREDENTIALS.key_path,
+      env_key: CREDENTIALS.env_key,
+      raise_if_missing_key: false
+    )
+    begin
+      puts credentials.read.presence || credentials.content_path.read
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      puts credentials.content_path.read
+    end
+  end
+
+  desc 'Edit the credentials file using the system editor'
+  task :edit do
+    require 'rails/command/helpers/editor'
+    include Rails::Command::Helpers::Editor
+
+    using_system_editor { CREDENTIALS.change { |tempfile| system_editor(tempfile) } }
+  end
+
+  desc 'Show the credentials stored in the credentials file'
+  task :show do
+    puts CREDENTIALS.read.presence || 'No decryptable credentials found'
+  end
+end


### PR DESCRIPTION
They're cribbed from Rails, more-or-less, but without the support for multiple environments, enrolling/dis-enrolling diff setup, etc. Just the bare minimum to make `rake credentials:edit` and `git diff` work.