### PR TITLE
Specify time zone in Docker env

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
   def project_root
     KAMAL.configured?[:config_file].join('../..')
   end
-  
+
   def user_for(host)
     Net::SSH::Config.for(host).fetch(:user, ENV.fetch('USER', nil))
   end
@@ -23,6 +23,8 @@ builder:
   args:
     RUBY_VERSION: <%= project_root.join('.ruby-version').read.strip %>
 env:
+  clear:
+    TZ: 'America/New_York'
   secret:
     - MASTER_KEY
 ssh:


### PR DESCRIPTION
Because the dates and times that come out of EAM have no time zone information (but are local times) [ActiveRecord is configured to use "local" time](https://github.com/umts/fleetfocus-api/blob/28bf66c40298f548c5d5d973131ee6674afa45b3/lib/application_record.rb#L3) for its datetimes. Inside the Docker container, though, local is UTC unless we configure it otherwise.